### PR TITLE
Update for data-nanomorph-component-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > Guard element against being touched by nanomorph
 
+<small>Requires nanomorph@5.4.0 or up.</small>
+
 ## Usage
 
 Useful with components that expect to keep a reference to their parent element,

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = function guard (el) {
 
 function createProxy (el) {
   var pel = document.createElement(el.nodeName)
+  // if you see this in devtools, something went wrong!
+  pel.dataset.proxy = 'true'
   pel.dataset.nanomorphComponentId = getComponentId(el)
   pel.isSameNode = (node) => getComponentId(pel) === getComponentId(node)
   proxies.set(el, pel)

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function guard (el) {
   // Short circuit all non-node
   if (!el.dataset) return el
   // Add the identifier the first time we encounter the node
-  if (!el.dataset.nanomorphComponentId) el.dataset.nanomorphComponentId = ns + (cnt++)
+  if (!getComponentId(el)) el.dataset.nanomorphComponentId = ns + (cnt++)
   // Not yet attached to the DOM
   if (!el.parentNode) return el
 
@@ -23,8 +23,12 @@ module.exports = function guard (el) {
 
 function createProxy (el) {
   var pel = document.createElement(el.nodeName)
-  pel.dataset.nanomorphComponentId = el.dataset.nanomorphComponentId
-  pel.isSameNode = (node) => node.dataset && pel.dataset.nanomorphComponentId === node.dataset.nanomorphComponentId
+  pel.dataset.nanomorphComponentId = getComponentId(el)
+  pel.isSameNode = (node) => getComponentId(pel) === getComponentId(node)
   proxies.set(el, pel)
   return pel
+}
+
+function getComponentId (el) {
+  return el.dataset && el.dataset.nanomorphComponentId
 }


### PR DESCRIPTION
**TODO**
- [x] Needs the next nanomorph release

This:
 - moves to the nanomorph-recognised attribute name
 - handles the case where a non-node is merged into a node (causing `node.dataset` to be null)
 - marks proxy nodes with a data attribute so they are easy to recognise in devtools